### PR TITLE
Simplify Ruff version management in CI/pre-commit

### DIFF
--- a/{{ cookiecutter.project_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_name }}/.pre-commit-config.yaml
@@ -7,22 +7,22 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.4
-    hooks:
-      - id: ruff-check
-        types_or:
-          - python
-          - pyi
-        args:
-          - --fix
-          - --exit-non-zero-on-fix
-      - id: ruff-format
-        types_or:
-          - python
-          - pyi
   - repo: local
     hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: uv run --no-project ruff check --fix --exit-non-zero-on-fix
+        language: system
+        types_or:
+          - python
+          - pyi
+      - id: ruff-format
+        name: ruff format
+        entry: uv run --no-project ruff format
+        language: system
+        types_or:
+          - python
+          - pyi
       - id: ty
         name: ty check
         entry: ty check . --ignore unresolved-import


### PR DESCRIPTION
Convert ruff pre-commit hook to a local hook running via uv run --no-project ruff. This ensures both CI and pre-commit always run the exact same Ruff version specified in requirements_dev.txt.