### PR TITLE
Remove invalid workflows: write permission

### DIFF
--- a/{{ cookiecutter.project_name }}/.github/workflows/cruft.yaml
+++ b/{{ cookiecutter.project_name }}/.github/workflows/cruft.yaml
@@ -4,10 +4,10 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
-  workflows: write
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   update:
@@ -59,6 +59,11 @@ jobs:
 
           if [ -n "$(find . -name '*.rej')" ]; then
             echo "Error: Cruft template update produced merge conflicts (.rej files). Please resolve manually."
+            exit 1
+          fi
+
+          if grep -rn 'cookiecutter\.' . --exclude-dir=.git --exclude=.cruft.json; then
+            echo "Error: Unrendered Cookiecutter Jinja tags detected in repository!"
             exit 1
           fi
 


### PR DESCRIPTION
Remove invalid workflows permission scope which is not supported by GitHub Actions.