### PR TITLE
chore: enable PLC0415 rule in Ruff config

### DIFF
--- a/{{ cookiecutter.project_name }}/.ruff.toml
+++ b/{{ cookiecutter.project_name }}/.ruff.toml
@@ -2,3 +2,5 @@ target-version = "py313"
 
 [lint]
 ignore = ["E501"]
+extend-select = ["PLC0415"]
+


### PR DESCRIPTION
Enables the Pylint PLC0415 lint rule (import-outside-toplevel) in the Ruff configuration to ensure all generated projects enforce top-level imports.